### PR TITLE
added norecursedirs to pytest.ini

### DIFF
--- a/{{cookiecutter.project_slug}}/pytest.ini
+++ b/{{cookiecutter.project_slug}}/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=config.settings.test
+{% if cookiecutter.js_task_runner != 'None' %}
+norecursedirs = node_modules
+{% endif %}


### PR DESCRIPTION
This is to ensure running `pytest` in project root works when using Python 3.6 (otherwise tries to run python tests in `node-gyp` node module and fails with:

```
―――――――――――――――――――――――――――――――――――――――――――― ERROR collecting node_modules/node-gyp/gyp/pylib/gyp/generator/xcode_test.py ――――――――――――――――――――――――――――――――――――――――――――
../venv/lib/python3.6/site-packages/_pytest/python.py:395: in _importtestmodule
    mod = self.fspath.pyimport(ensuresyspath=importmode)
../venv/lib/python3.6/site-packages/py/_path/local.py:662: in pyimport
    __import__(modname)
E     File "/Users/ivan/Projects/Minireference/ClassroomLinksProject/classroomlinks/node_modules/node-gyp/gyp/pylib/gyp/__init__.py", line 37
E       print '%s:%s:%d:%s %s' % (mode.upper(), os.path.basename(ctx[0]),
E                            ^
E   SyntaxError: invalid syntax
```